### PR TITLE
chore(governance): security baseline checks and docs sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap verify smoke release-check cli-contract db-migrations e2e-smoke doctor toolchain security governance milestone sonar-status
+.PHONY: bootstrap verify smoke release-check cli-contract db-migrations e2e-smoke doctor toolchain security governance governance-check milestone sonar-status
 
 bootstrap:
 	./scripts/bootstrap.sh
@@ -35,6 +35,9 @@ security:
 
 governance:
 	./scripts/apply_main_ruleset.sh
+
+governance-check:
+	./scripts/check_repo_governance.sh
 
 milestone:
 	./scripts/create_alpha_milestone_issues.sh

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,6 +37,6 @@ Include:
 - Semgrep suppressions are allowed only via registry with owner + issue + expiry
   (see `docs/SEMGREP_POLICY.md` and `.github/semgrep_suppressions.json`).
 - Temporary CVE exceptions must have owner + expiry + tracking issue
-  (see ADR-013 in `docs/DECISIONS.md`).
+  (see `docs/runbooks/security.md`).
 - Sonar quality gate is focused on New Code to prevent legacy noise masking new risks
-  (see ADR-014 in `docs/DECISIONS.md`).
+  (see `docs/runbooks/repo-governance.md` and `docs/runbooks/release.md`).

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -13,6 +13,7 @@ Pre-release checklist:
 6. `uv build --wheel` succeeds.
 7. Version and tag line are aligned (`0.1.0a1` / `v0.1.0-alpha.1`).
 8. SonarCloud check-run is green for `origin/main` (`./scripts/check_sonar_status.sh --required`).
+9. Governance baseline is green (`./scripts/check_repo_governance.sh`).
 
 Release commands:
 
@@ -23,6 +24,7 @@ Release commands:
 uv run pytest tests/test_db_migrations.py -q
 uv build --wheel
 ./scripts/check_sonar_status.sh --required
+./scripts/check_repo_governance.sh
 git tag -a v0.1.0-alpha.1 -m "voiceforge alpha0.1"
 ```
 

--- a/docs/runbooks/repo-governance.md
+++ b/docs/runbooks/repo-governance.md
@@ -19,6 +19,18 @@ Required policies:
 7. Restrict force pushes and deletions.
 
 `scripts/apply_main_ruleset.sh` can apply these settings via GitHub API (requires authenticated `gh`).
+`scripts/check_repo_governance.sh` validates active ruleset and required checks.
+
+## Security Settings Baseline
+
+Repository-level security baseline:
+1. Dependabot alerts endpoint enabled.
+2. Dependabot security updates enabled.
+3. Secret scanning enabled.
+4. Secret scanning push protection enabled.
+
+Verification command:
+- `./scripts/check_repo_governance.sh`
 
 ## Alpha0.1 Milestone Planning
 

--- a/scripts/check_repo_governance.sh
+++ b/scripts/check_repo_governance.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${1:-}"
+ruleset_name="main-hardening-alpha0.1"
+expected_checks=("quality (3.12)" "quality (3.13)" "cli-contract" "db-migrations" "e2e-smoke")
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "[FAIL] gh CLI is required"
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "[FAIL] GitHub auth required. Run: gh auth login"
+  exit 1
+fi
+
+if [[ -z "${repo}" ]]; then
+  repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+fi
+
+errors=0
+
+ok() {
+  echo "[OK] $*"
+}
+
+fail() {
+  echo "[FAIL] $*"
+  errors=$((errors + 1))
+}
+
+contains_line() {
+  local needle="$1"
+  shift
+  local value
+  for value in "$@"; do
+    if [[ "${value}" == "${needle}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+echo "governance-check: repo=${repo}"
+
+visibility="$(gh api "repos/${repo}" --jq '.visibility')"
+if [[ "${visibility}" == "public" ]]; then
+  ok "repo visibility is public"
+else
+  fail "repo visibility expected public, got ${visibility}"
+fi
+
+ruleset_id="$(gh api "repos/${repo}/rulesets" --jq ".[] | select(.name==\"${ruleset_name}\") | .id" | head -n1 || true)"
+if [[ -z "${ruleset_id}" ]]; then
+  fail "ruleset ${ruleset_name} not found"
+else
+  ok "ruleset ${ruleset_name} found (id=${ruleset_id})"
+  enforcement="$(gh api "repos/${repo}/rulesets/${ruleset_id}" --jq '.enforcement')"
+  if [[ "${enforcement}" == "active" ]]; then
+    ok "ruleset enforcement is active"
+  else
+    fail "ruleset enforcement expected active, got ${enforcement}"
+  fi
+
+  pr_required="$(gh api "repos/${repo}/rulesets/${ruleset_id}" --jq '.rules[] | select(.type=="pull_request") | .parameters.required_approving_review_count')"
+  if [[ "${pr_required}" == "0" ]]; then
+    ok "solo PR mode enabled (required approvals=0)"
+  else
+    fail "required approvals expected 0, got ${pr_required}"
+  fi
+
+  mapfile -t checks < <(gh api "repos/${repo}/rulesets/${ruleset_id}" --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context')
+  for expected in "${expected_checks[@]}"; do
+    if contains_line "${expected}" "${checks[@]}"; then
+      ok "required check present: ${expected}"
+    else
+      fail "required check missing: ${expected}"
+    fi
+  done
+fi
+
+dependabot_updates="$(gh api "repos/${repo}" --jq '.security_and_analysis.dependabot_security_updates.status')"
+if [[ "${dependabot_updates}" == "enabled" ]]; then
+  ok "dependabot security updates enabled"
+else
+  fail "dependabot security updates are ${dependabot_updates}"
+fi
+
+secret_scanning="$(gh api "repos/${repo}" --jq '.security_and_analysis.secret_scanning.status')"
+if [[ "${secret_scanning}" == "enabled" ]]; then
+  ok "secret scanning enabled"
+else
+  fail "secret scanning is ${secret_scanning}"
+fi
+
+push_protection="$(gh api "repos/${repo}" --jq '.security_and_analysis.secret_scanning_push_protection.status')"
+if [[ "${push_protection}" == "enabled" ]]; then
+  ok "secret scanning push protection enabled"
+else
+  fail "secret scanning push protection is ${push_protection}"
+fi
+
+set +e
+gh api "repos/${repo}/vulnerability-alerts" -H "Accept: application/vnd.github+json" >/dev/null 2>&1
+vuln_status=$?
+set -e
+if [[ ${vuln_status} -eq 0 ]]; then
+  ok "vulnerability alerts endpoint enabled"
+else
+  fail "vulnerability alerts endpoint not enabled"
+fi
+
+set +e
+open_dependabot="$(gh api "repos/${repo}/dependabot/alerts?state=open" --jq 'length' 2>/dev/null)"
+dep_status=$?
+set -e
+if [[ ${dep_status} -eq 0 ]]; then
+  ok "dependabot alerts endpoint available (open=${open_dependabot})"
+else
+  fail "dependabot alerts endpoint unavailable"
+fi
+
+echo "governance-check-summary: errors=${errors}"
+if [[ ${errors} -ne 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `scripts/check_repo_governance.sh` to validate ruleset, required checks, and repository security settings
- add `governance-check` target to `Makefile`
- update governance/release runbooks with governance-check step
- fix stale references in `SECURITY.md` to existing runbooks

## Repository settings applied
- enabled vulnerability alerts endpoint
- enabled dependabot security updates
- enabled secret scanning and push protection
- dismissed dependabot alert for `CVE-2025-69872` as temporary tolerable risk (no patched version yet)

## Validation
- `./scripts/check_repo_governance.sh`
- `./scripts/verify_pr.sh`
- `./scripts/smoke_clean_env.sh`
