### PR TITLE
chore(quality): new-code coverage gate + e2e smoke expansion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
       UV_VERSION: "0.8"
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7
         with:
           python-version: ${{ matrix.python-version }}
@@ -27,12 +29,16 @@ jobs:
       - run: ./scripts/check_toolchain.sh
       - run: uv run ruff check src tests scripts
       - run: uv run mypy src/voiceforge/core src/voiceforge/llm src/voiceforge/rag src/voiceforge/stt --ignore-missing-imports
-      - run: uv run pytest tests -q --cov=src/voiceforge --cov-report=xml --cov-fail-under=0
+      - run: uv run pytest tests -q --cov=src/voiceforge --cov-report=xml --cov-report=json --cov-fail-under=0
+      - if: matrix.python-version == '3.12'
+        run: ./scripts/check_new_code_coverage.sh --fail-under 85
       - uses: actions/upload-artifact@v6
         if: always()
         with:
           name: coverage-${{ matrix.python-version }}
-          path: coverage.xml
+          path: |
+            coverage.xml
+            coverage.json
 
   cli-contract:
     name: cli-contract

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap verify smoke release-check cli-contract db-migrations e2e-smoke doctor toolchain security governance governance-check milestone sonar-status
+.PHONY: bootstrap verify smoke release-check cli-contract db-migrations e2e-smoke doctor toolchain security governance governance-check new-code-coverage milestone sonar-status
 
 bootstrap:
 	./scripts/bootstrap.sh
@@ -38,6 +38,9 @@ governance:
 
 governance-check:
 	./scripts/check_repo_governance.sh
+
+new-code-coverage:
+	./scripts/check_new_code_coverage.sh
 
 milestone:
 	./scripts/create_alpha_milestone_issues.sh

--- a/docs/runbooks/alpha0.1-dod.md
+++ b/docs/runbooks/alpha0.1-dod.md
@@ -42,7 +42,8 @@ A build is considered ready for alpha0.1 only when all checks below are true.
 2. `./scripts/smoke_clean_env.sh` passes.
 3. `./scripts/check_cli_contract.sh` passes.
 4. DB migrations tests pass (`uv run pytest tests/test_db_migrations.py -q`).
-5. Security scans pass with current temporary exception:
+5. New-code coverage gate passes (`./scripts/check_new_code_coverage.sh`).
+6. Security scans pass with current temporary exception:
    - `CVE-2025-69872` is ignored until upstream fix is released.
 
 ## Release readiness

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -14,6 +14,7 @@ Pre-release checklist:
 7. Version and tag line are aligned (`0.1.0a1` / `v0.1.0-alpha.1`).
 8. SonarCloud check-run is green for `origin/main` (`./scripts/check_sonar_status.sh --required`).
 9. Governance baseline is green (`./scripts/check_repo_governance.sh`).
+10. New-code coverage gate passes (`./scripts/check_new_code_coverage.sh`).
 
 Release commands:
 
@@ -25,6 +26,7 @@ uv run pytest tests/test_db_migrations.py -q
 uv build --wheel
 ./scripts/check_sonar_status.sh --required
 ./scripts/check_repo_governance.sh
+./scripts/check_new_code_coverage.sh
 git tag -a v0.1.0-alpha.1 -m "voiceforge alpha0.1"
 ```
 

--- a/scripts/check_new_code_coverage.sh
+++ b/scripts/check_new_code_coverage.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+coverage_file="coverage.json"
+fail_under="85"
+base_ref=""
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/check_new_code_coverage.sh [options]
+
+Options:
+  --coverage-file <path>  Coverage JSON file (default: coverage.json)
+  --fail-under <percent>  Minimum required coverage for changed executable lines (default: 85)
+  --base <git-ref>        Git base ref for diff (default: auto-detect)
+  -h, --help              Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --coverage-file)
+      coverage_file="${2:-}"
+      shift 2
+      ;;
+    --fail-under)
+      fail_under="${2:-}"
+      shift 2
+      ;;
+    --base)
+      base_ref="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -f "${coverage_file}" ]]; then
+  echo "Coverage file not found: ${coverage_file}" >&2
+  exit 1
+fi
+
+if [[ -z "${base_ref}" ]]; then
+  if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" && -n "${GITHUB_BASE_REF:-}" ]]; then
+    base_ref="origin/${GITHUB_BASE_REF}"
+  elif git rev-parse --verify --quiet origin/main >/dev/null; then
+    base_ref="origin/main"
+  elif git rev-parse --verify --quiet HEAD~1 >/dev/null; then
+    base_ref="HEAD~1"
+  else
+    echo "Unable to auto-detect base ref (origin/main or HEAD~1 missing)." >&2
+    exit 1
+  fi
+fi
+
+if ! git rev-parse --verify --quiet "${base_ref}" >/dev/null; then
+  case "${base_ref}" in
+    origin/*)
+      branch="${base_ref#origin/}"
+      git fetch --no-tags --prune --depth=300 origin \
+        "refs/heads/${branch}:refs/remotes/origin/${branch}" >/dev/null 2>&1 || true
+      ;;
+  esac
+fi
+
+if ! git rev-parse --verify --quiet "${base_ref}" >/dev/null; then
+  echo "Base ref is not available: ${base_ref}" >&2
+  exit 1
+fi
+
+python - "${coverage_file}" "${base_ref}" "${fail_under}" <<'PY'
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+coverage_path = Path(sys.argv[1])
+base_ref = sys.argv[2]
+fail_under = float(sys.argv[3])
+
+if not coverage_path.is_file():
+    raise SystemExit(f"Coverage file not found: {coverage_path}")
+
+diff_cmd = ["git", "diff", "--unified=0", "--no-color", f"{base_ref}...HEAD", "--", "src/voiceforge"]
+diff = subprocess.run(diff_cmd, check=True, text=True, capture_output=True).stdout
+
+changed_lines_by_file: dict[str, set[int]] = {}
+current_file: str | None = None
+hunk_re = re.compile(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+for raw_line in diff.splitlines():
+    if raw_line.startswith("+++ b/"):
+        path = raw_line[6:]
+        if path.startswith("src/voiceforge/") and path.endswith(".py"):
+            current_file = os.path.normpath(path)
+            changed_lines_by_file.setdefault(current_file, set())
+        else:
+            current_file = None
+        continue
+    if current_file is None:
+        continue
+    if not raw_line.startswith("@@"):
+        continue
+    match = hunk_re.match(raw_line)
+    if not match:
+        continue
+    start = int(match.group(1))
+    count = int(match.group(2) or "1")
+    if count <= 0:
+        continue
+    changed_lines_by_file[current_file].update(range(start, start + count))
+
+if not changed_lines_by_file:
+    print(f"new-code-coverage: no changed python lines under src/voiceforge vs {base_ref}")
+    raise SystemExit(0)
+
+coverage = json.loads(coverage_path.read_text())
+files_cov: dict[str, dict[str, list[int]]] = coverage.get("files", {})
+
+
+def find_cov_entry(path: str) -> dict[str, list[int]] | None:
+    norm = os.path.normpath(path)
+    if norm in files_cov:
+        return files_cov[norm]
+    for key, value in files_cov.items():
+        if os.path.normpath(key).endswith(norm):
+            return value
+    return None
+
+
+total_covered = 0
+total_relevant = 0
+rows: list[tuple[str, int, int, float]] = []
+
+for path in sorted(changed_lines_by_file):
+    entry = find_cov_entry(path)
+    if entry is None:
+        rows.append((path, 0, 0, 100.0))
+        continue
+    changed = changed_lines_by_file[path]
+    executed = set(entry.get("executed_lines", []))
+    missing = set(entry.get("missing_lines", []))
+    measurable = executed | missing
+    relevant = changed & measurable
+    covered = relevant & executed
+    relevant_n = len(relevant)
+    covered_n = len(covered)
+    pct = 100.0 if relevant_n == 0 else (covered_n * 100.0 / relevant_n)
+    rows.append((path, covered_n, relevant_n, pct))
+    total_covered += covered_n
+    total_relevant += relevant_n
+
+print(f"new-code-coverage: base={base_ref}, threshold={fail_under:.1f}%")
+for path, covered_n, relevant_n, pct in rows:
+    print(f"  {path}: {covered_n}/{relevant_n} ({pct:.1f}%)")
+
+if total_relevant == 0:
+    print("new-code-coverage: no executable changed lines detected")
+    raise SystemExit(0)
+
+overall = total_covered * 100.0 / total_relevant
+print(f"new-code-coverage-summary: {total_covered}/{total_relevant} ({overall:.1f}%)")
+if overall < fail_under:
+    raise SystemExit(
+        f"new-code-coverage FAILED: {overall:.1f}% < {fail_under:.1f}% on changed executable lines"
+    )
+print("new-code-coverage: OK")
+PY

--- a/scripts/verify_pr.sh
+++ b/scripts/verify_pr.sh
@@ -20,26 +20,29 @@ run_gitleaks() {
   return 1
 }
 
-echo "[1/7] Toolchain"
+echo "[1/8] Toolchain"
 ./scripts/check_toolchain.sh
 
-echo "[2/7] Ruff"
+echo "[2/8] Ruff"
 uv run ruff check src tests scripts
 
-echo "[3/7] Mypy"
+echo "[3/8] Mypy"
 uv run mypy src/voiceforge/core src/voiceforge/llm src/voiceforge/rag src/voiceforge/stt --ignore-missing-imports
 
-echo "[4/7] Tests"
-uv run pytest tests -q
+echo "[4/8] Tests + Coverage"
+uv run pytest tests -q --cov=src/voiceforge --cov-report=xml --cov-report=json --cov-fail-under=0
 
-echo "[5/7] CLI contract"
+echo "[5/8] New-code coverage"
+./scripts/check_new_code_coverage.sh
+
+echo "[6/8] CLI contract"
 ./scripts/check_cli_contract.sh
 
-echo "[6/7] Security"
+echo "[7/8] Security"
 uv run pip-audit --desc --ignore-vuln CVE-2025-69872
 uv run bandit -r src -ll -q --configfile .bandit.yaml
 
-echo "[7/7] Gitleaks"
+echo "[8/8] Gitleaks"
 run_gitleaks
 
 echo "verify_pr.sh: ALL CHECKS PASSED"


### PR DESCRIPTION
## Summary
- add `scripts/check_new_code_coverage.sh` to enforce coverage on changed executable lines only
- wire new-code coverage into `scripts/verify_pr.sh` and `Makefile`
- run new-code coverage gate in CI `quality (3.12)` job
- extend e2e smoke tests with install/uninstall service flow (mocked systemctl)
- sync runbooks (`alpha0.1-dod`, `release`) with new gate

## Validation
- `./scripts/verify_pr.sh`
- `./scripts/smoke_clean_env.sh`
- `uv run pytest tests/test_cli_e2e_smoke.py -q`
