### PR TITLE
docs(governance): PR template reference CLI contract test

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@
 
 - [ ] I ran `./scripts/verify_pr.sh`
 - [ ] I ran `./scripts/smoke_clean_env.sh`
-- [ ] CLI contract is unchanged (9 commands) or intentionally updated with explicit note
+- [ ] CLI contract is unchanged (see `tests/test_cli_surface.py`) or intentionally updated with explicit note
 - [ ] DB migration behavior on clean and existing DB is covered by tests
 - [ ] Config/env contract docs are up to date (`docs/runbooks/config-env-contract.md`)
 - [ ] `CHANGELOG.md` updated for user-visible changes


### PR DESCRIPTION
Reference `tests/test_cli_surface.py` in DoD instead of hardcoded "9 commands" so the template stays in sync with the actual CLI surface.

Made with [Cursor](https://cursor.com)